### PR TITLE
Add FreeBSD support, do not fail on unsupported OSes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,8 +15,14 @@ class open_vm_tools::params {
       $hasstatus = true
     }
 
+    freebsd: {
+      $packages = ['open-vm-tools-nox11']
+      $service = ['vmware-guestd', 'vmware-kmod']
+      $hasstatus = true
+    }
+
     default: {
-      fail("Unsupported OS: ${::operatingsystem}")
+      warning("Unsupported OS: ${::operatingsystem}")
     }
   }
 }


### PR DESCRIPTION
This change adds FreeBSD support and changes behaviour on unsupported OSes from fail to warning which prevents from failing entire provisioning process.